### PR TITLE
use format_string for course names

### DIFF
--- a/course_overview.php
+++ b/course_overview.php
@@ -233,16 +233,17 @@ if ($courseid == 0) {
         get_string('allcourses', 'block_fn_mentor').'</a></div>';
 }
 foreach ($enrolledcourses as $enrolledcourse) {
+       $course_fullname = format_string($enrolledcourse->fullname); //allow mlang filters to process language strings
     if ($courseid == $enrolledcourse->id) {
         $courselist .= '<div class="courselist active">
             <img class="mentees-course-bullet" src="'.$CFG->wwwroot.'/blocks/fn_mentor/pix/b.gif">'.
             '<a href="'.$CFG->wwwroot.'/blocks/fn_mentor/course_overview_single.php?menteeid='.
-            $menteeid.'&courseid='.$enrolledcourse->id.'">'.$enrolledcourse->fullname.'</a></div>';
+            $menteeid.'&courseid='.$enrolledcourse->id.'">'.$course_fullname.'</a></div>';
     } else {
         $courselist .= '<div class="courselist">
             <img class="mentees-course-bullet" src="'.$CFG->wwwroot.'/blocks/fn_mentor/pix/b.gif">'.
             '<a href="'.$CFG->wwwroot.'/blocks/fn_mentor/course_overview_single.php?menteeid='.
-            $menteeid.'&courseid='.$enrolledcourse->id.'">'.$enrolledcourse->fullname.'</a></div>';
+            $menteeid.'&courseid='.$enrolledcourse->id.'">'.$course_fullname.'</a></div>';
     }
 }
 
@@ -322,7 +323,8 @@ echo '<div id="mentee-course-overview-center">';
 if ($enrolledcourses) {
 
     foreach ($enrolledcourses as $enrolledcourse) {
-
+        $course_fullname = format_string($enrolledcourse->fullname); //allow mlang filters to process language strings
+        
         if ($courseid && ($courseid <> $enrolledcourse->id)) {
             continue;
         }
@@ -350,7 +352,7 @@ if ($enrolledcourses) {
             $enrolledcourse->id . '" onclick="window.open(\'' . $CFG->wwwroot . '/course/view.php?id=' .
             $enrolledcourse->id . '\', \'\', \'width=800,height=600,toolbar=no,location=no,menubar=no,'.
             'copyhistory=no,status=no,directories=no,scrollbars=yes,resizable=yes\'); return false;" class="" >' .
-            $enrolledcourse->fullname . '</a></div>';
+            $course_fullname . '</a></div>';
 
         echo '<div class="overview-teacher">';
         echo '<table class="mentee-teacher-table">';

--- a/course_overview_single.php
+++ b/course_overview_single.php
@@ -241,15 +241,17 @@ if ($courseid == 0) {
         $menteeid.'&courseid=0">'.get_string('allcourses', 'block_fn_mentor').'</a></div>';
 }
 foreach ($enrolledcourses as $enrolledcourse) {
+    $course_fullname = format_string($enrolledcourse->fullname); //allow mlang filters to process language strings
+    
     if ($courseid == $enrolledcourse->id) {
         $courselist .= '<div class="courselist active"><img class="mentees-course-bullet" src="'.
             $CFG->wwwroot.'/blocks/fn_mentor/pix/b.gif"><a href="'.$CFG->wwwroot.
             '/blocks/fn_mentor/course_overview_single.php?menteeid='.$menteeid.
-            '&courseid='.$enrolledcourse->id.'">'.$enrolledcourse->fullname.'</a></div>';
+            '&courseid='.$enrolledcourse->id.'">'.$course_fullname.'</a></div>';
     } else {
         $courselist .= '<div class="courselist"><img class="mentees-course-bullet" src="'.$CFG->wwwroot.
             '/blocks/fn_mentor/pix/b.gif"><a href="'.$CFG->wwwroot.'/blocks/fn_mentor/course_overview_single.php?menteeid='.
-            $menteeid.'&courseid='.$enrolledcourse->id.'">'.$enrolledcourse->fullname.'</a></div>';
+            $menteeid.'&courseid='.$enrolledcourse->id.'">'.$course_fullname.'</a></div>';
     }
 }
 
@@ -284,12 +286,13 @@ if ($navpage == 'overview') {
 }
 
 // CENTER.
+$course_fullname = format_string($course->fullname); //allow mlang filters to process language strings
 echo '<div id="mentee-course-overview-center-single" class="block">'.
     '<div id="mentee-course-overview-center-menu-container">';
 echo '<div class="mentee-course-overview-center-course-title"><a  href="'.$CFG->wwwroot.'/course/view.php?id='.
     $course->id.'" onclick="window.open(\''.$CFG->wwwroot.'/course/view.php?id='.$course->id.
     '\', \'\', \'width=800,height=600,toolbar=no,location=no,menubar=no,copyhistory=no,status=no,directories=no,'.
-    'scrollbars=yes,resizable=yes\'); return false;" class="" >'.$course->fullname.'</a></div>';
+    'scrollbars=yes,resizable=yes\'); return false;" class="" >'.$course_fullname.'</a></div>';
 
 echo '<div class="mentee-course-overview-center-course-menu">
           <table class="mentee-menu">


### PR DESCRIPTION
Any course names in which the mlang filters are active did not render.  I have used format_string() to accommodate this.  I created a variable for this, but it could probably be incorporated directly into the anchor tag, but I think we would need to use the html_writer() function to do this.  I fear that is a bigger job so I did not want to undertake that yet. 